### PR TITLE
Restore Config to fix compilation

### DIFF
--- a/src/lia/util/net/common/Config.java
+++ b/src/lia/util/net/common/Config.java
@@ -942,6 +942,27 @@ public class Config {
         } 
         return rtp;
     }
+    
+    private int getRandomPort(int defaultPort)
+    {
+        int randomPort = -1;
+        try {
+            Random r = new Random();
+            randomPort = r.nextInt(((defaultPort + portRange) - defaultPort) + 1) + defaultPort;
+            logger.log(Level.INFO, "Auto FDT on port " + randomPort);
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    new FDTMain();
+                }
+            }, "FDT custom port " + randomPort).start();
+        }
+        catch (Exception e)
+        {
+            logger.log(Level.INFO, " FAILED auto FDT on port " + randomPort);
+        }
+        return randomPort;
+    }
 
     private int findAvailablePort() {
 


### PR DESCRIPTION
Fix issue #75 

### Summary
Running the command _build-all.sh_ encountered a compile error. Inspecting the code, the method `getRandomPort` was missing.
```
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /home/rednesp/fdt_github/src/lia/util/net/common/Config.java:[926,23] error: cannot find symbol
```

This PR restores the code with the private method getRandomPort from release 0.26.2 .